### PR TITLE
Fix google fonts link

### DIFF
--- a/scss/app.scss
+++ b/scss/app.scss
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Raleway:100,300);
+@import url(https://fonts.googleapis.com/css?family=Raleway:100,300);
 @import "settings";
 @import "foundation";
 @import "icons";


### PR DESCRIPTION
Hey,

using https, otherwise the request will fail on all https sites.

Could you recompile the css (because you don't have an automated setup here), create a new release and hit the update button in the extension store? Thanks :)
